### PR TITLE
Locks fix, commands timeout support

### DIFF
--- a/executors/kubeexec/georep.go
+++ b/executors/kubeexec/georep.go
@@ -45,7 +45,11 @@ func (s *KubeExecutor) GeoReplicationCreate(host, volume string, geoRep *executo
 	if geoRep.SlaveSSHPort != 0 {
 		sshPort = fmt.Sprintf(" ssh-port %d ", geoRep.SlaveSSHPort)
 	}
-	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s create%s%s force", volume, geoRep.SlaveHost, geoRep.SlaveVolume, sshPort, geoRep.ActionParams["option"])
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s create%s%s", volume, geoRep.SlaveHost, geoRep.SlaveVolume, sshPort, geoRep.ActionParams["option"])
+
+	if force, ok := geoRep.ActionParams["force"]; ok && force == "true" {
+		cmd = fmt.Sprintf("%s %s", cmd, "force")
+	}
 
 	// create session and then make volume read-only
 	commands := []string{cmd, cmdChangelogsEnabled(volume, false)}
@@ -73,7 +77,11 @@ func (s *KubeExecutor) GeoReplicationAction(host, volume, action string, geoRep 
 	godbc.Require(geoRep.SlaveHost != "")
 	godbc.Require(geoRep.SlaveVolume != "")
 
-	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s %s force", volume, geoRep.SlaveHost, geoRep.SlaveVolume, action)
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s %s", volume, geoRep.SlaveHost, geoRep.SlaveVolume, action)
+
+	if force, ok := geoRep.ActionParams["force"]; ok && force == "true" {
+		cmd = fmt.Sprintf("%s %s", cmd, "force")
+	}
 
 	commands := []string{cmd}
 	apiAction := api.GeoReplicationActionType(action)

--- a/executors/kubeexec/georep.go
+++ b/executors/kubeexec/georep.go
@@ -53,18 +53,18 @@ func (s *KubeExecutor) GeoReplicationCreate(host, volume string, geoRep *executo
 
 	// create session and then make volume read-only
 	commands := []string{cmd, cmdChangelogsEnabled(volume, false)}
-    for _, command := range commands {
-	    for i := 0; ; i++ {
-		    if _, err := s.RemoteExecutor.RemoteCommandExecute(host, []string{ command }, 10); err != nil {
-			    if i >= 50 {
-				    return err
-			    }
-			    time.Sleep(3 * time.Second)
-		    } else {
-			    break
-            }
-	    }
-    }
+	for _, command := range commands {
+		for i := 0; ; i++ {
+			if _, err := s.RemoteExecutor.RemoteCommandExecute(host, []string{command}, 2); err != nil {
+				if i >= 50 {
+					return err
+				}
+				time.Sleep(3 * time.Second)
+			} else {
+				break
+			}
+		}
+	}
 	return nil
 }
 
@@ -91,18 +91,18 @@ func (s *KubeExecutor) GeoReplicationAction(host, volume, action string, geoRep 
 		commands = append(commands, cmdChangelogsEnabled(volume, false))
 	}
 
-    for _, command := range commands {
-	    for i := 0; ; i++ {
-		    if _, err := s.RemoteExecutor.RemoteCommandExecute(host, []string{ command }, 10); err != nil {
-			    if i >= 50 {
-				    return err
-			    }
-			    time.Sleep(3 * time.Second)
-		    } else {
-			    break
-            }
-	    }
-    }
+	for _, command := range commands {
+		for i := 0; ; i++ {
+			if _, err := s.RemoteExecutor.RemoteCommandExecute(host, []string{command}, 2); err != nil {
+				if i >= 50 {
+					return err
+				}
+				time.Sleep(3 * time.Second)
+			} else {
+				break
+			}
+		}
+	}
 	return nil
 }
 

--- a/executors/kubeexec/georep.go
+++ b/executors/kubeexec/georep.go
@@ -150,12 +150,12 @@ func (s *KubeExecutor) GeoReplicationVolumeStatus(host, volume string) (*executo
 		GeoRepStatus executors.GeoReplicationStatus `xml:"geoRep"`
 	}
 
-	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s status --xml", volume)
+	cmd := fmt.Sprintf("sleep 70 && gluster --mode=script volume geo-replication %s status --xml", volume)
 	commands := []string{cmd}
 
 	var output []string
 	var err error
-	if output, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
+	if output, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 1); err != nil {
 		return nil, err
 	}
 

--- a/executors/kubeexec/georep.go
+++ b/executors/kubeexec/georep.go
@@ -45,11 +45,7 @@ func (s *KubeExecutor) GeoReplicationCreate(host, volume string, geoRep *executo
 	if geoRep.SlaveSSHPort != 0 {
 		sshPort = fmt.Sprintf(" ssh-port %d ", geoRep.SlaveSSHPort)
 	}
-	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s create%s%s", volume, geoRep.SlaveHost, geoRep.SlaveVolume, sshPort, geoRep.ActionParams["option"])
-
-	if force, ok := geoRep.ActionParams["force"]; ok && force == "true" {
-		cmd = fmt.Sprintf("%s %s", cmd, "force")
-	}
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s create%s%s force", volume, geoRep.SlaveHost, geoRep.SlaveVolume, sshPort, geoRep.ActionParams["option"])
 
 	// create session and then make volume read-only
 	commands := []string{cmd, cmdChangelogsEnabled(volume, false)}
@@ -77,11 +73,7 @@ func (s *KubeExecutor) GeoReplicationAction(host, volume, action string, geoRep 
 	godbc.Require(geoRep.SlaveHost != "")
 	godbc.Require(geoRep.SlaveVolume != "")
 
-	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s %s", volume, geoRep.SlaveHost, geoRep.SlaveVolume, action)
-
-	if force, ok := geoRep.ActionParams["force"]; ok && force == "true" {
-		cmd = fmt.Sprintf("%s %s", cmd, force)
-	}
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s %s::%s %s force", volume, geoRep.SlaveHost, geoRep.SlaveVolume, action)
 
 	commands := []string{cmd}
 	apiAction := api.GeoReplicationActionType(action)
@@ -150,12 +142,12 @@ func (s *KubeExecutor) GeoReplicationVolumeStatus(host, volume string) (*executo
 		GeoRepStatus executors.GeoReplicationStatus `xml:"geoRep"`
 	}
 
-	cmd := fmt.Sprintf("sleep 70 && gluster --mode=script volume geo-replication %s status --xml", volume)
+	cmd := fmt.Sprintf("gluster --mode=script volume geo-replication %s status --xml", volume)
 	commands := []string{cmd}
 
 	var output []string
 	var err error
-	if output, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 1); err != nil {
+	if output, err = s.RemoteExecutor.RemoteCommandExecute(host, commands, 10); err != nil {
 		return nil, err
 	}
 

--- a/executors/kubeexec/kubeexec.go
+++ b/executors/kubeexec/kubeexec.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
@@ -212,7 +213,8 @@ func (k *KubeExecutor) ConnectAndExec(host, resource string,
 			Name(podName).
 			Namespace(k.namespace).
 			SubResource("exec").
-			Param("container", containerName)
+			Param("container", containerName).
+			Timeout(time.Minute * time.Duration(timeoutMinutes))
 		req.VersionedParams(&api.PodExecOptions{
 			Container: containerName,
 			Command:   []string{"/bin/bash", "-c", command},


### PR DESCRIPTION
Initial problem is that for some reason remote commands sometimes stuck during execution, so heketi can not release lock on remote hosts. It seems that we can solve this stuck using timeouts, so we decided to enable default timeout of 10 minutes for all remote commands.

Moreover, for geo-rep create/start/stop/delete/pause/resume & changelog commands, which additionally have 50 retries, we set this timeout to 2 minutes only. We also enabled "force" mode on retries for create/start/stop/pause/resume commands (delete&changelog do not support it).

As for "force" mode - it is required to successfully finish commands after cases when timeout happened, we got error and performed retry, but in fact command was executed successfully on previous try - without "force" all our retries will fail because session is already "created/started/stopped/etc". It is not a big problem, but heketi will consume threads and locks which can harm performance. Additionally, with "force" on retries we will not get error in some cases for which we got errors earlier. For example, if host is unavailable "create/start/stop" command without "force" will fail for all hosts, with "force" it will succeed for available hosts. I think it is safe to ignore such errors because in fact we ignored them anyway, still they can be spotted using some gluster check script