### PR TITLE
Update app/glusterfs/volume_entry.go NewVolumeEntryFromRequest to fix Many Bricks per Node issue

### DIFF
--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -138,6 +138,10 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 	// If it is zero, then no volume options are set.
 	vol.GlusterVolumeOptions = req.GlusterVolumeOptions
 
+    //Set many bricks per node volume parameters
+	vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions, "cluster.brick-multiplex on")
+	vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions, "transport.listen-backlog 100")
+
 	if vol.Info.Block {
 		if err := vol.SetRawCapacity(req.Size); err != nil {
 			logger.Err(err)

--- a/apps/glusterfs/volume_entry.go
+++ b/apps/glusterfs/volume_entry.go
@@ -14,6 +14,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -138,9 +139,15 @@ func NewVolumeEntryFromRequest(req *api.VolumeCreateRequest) *VolumeEntry {
 	// If it is zero, then no volume options are set.
 	vol.GlusterVolumeOptions = req.GlusterVolumeOptions
 
-    //Set many bricks per node volume parameters
+	//Set many bricks per node volume parameters
 	vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions, "cluster.brick-multiplex on")
-	vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions, "transport.listen-backlog 100")
+
+	transportListenBacklogOption, exists := os.LookupEnv("HEKETI_TRANSPORT_LISTEN_BACKLOG_OPTION")
+	if exists {
+		vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions, fmt.Sprintf("transport.listen-backlog %v", transportListenBacklogOption))
+	} else {
+		vol.GlusterVolumeOptions = append(vol.GlusterVolumeOptions, "transport.listen-backlog 100")
+	}
 
 	if vol.Info.Block {
 		if err := vol.SetRawCapacity(req.Size); err != nil {

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -69,10 +69,6 @@ func (s *CmdExecutor) VolumeCreate(host string,
 
 	commands = append(commands, s.createVolumeOptionsCommand(volume)...)
 
-	//Set many bricks per node volume parameters
-    commands = append(commands, fmt.Sprintf("gluster --mode=script volume %v set cluster.brick-multiplex on", volume.Name))
-    commands = append(commands, fmt.Sprintf("gluster --mode=script volume %v set transport.listen-backlog 100", volume.Name))
-
 	commands = append(commands, fmt.Sprintf("gluster --mode=script volume start %v", volume.Name))
 
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)

--- a/executors/cmdexec/volume.go
+++ b/executors/cmdexec/volume.go
@@ -69,6 +69,10 @@ func (s *CmdExecutor) VolumeCreate(host string,
 
 	commands = append(commands, s.createVolumeOptionsCommand(volume)...)
 
+	//Set many bricks per node volume parameters
+    commands = append(commands, fmt.Sprintf("gluster --mode=script volume %v set cluster.brick-multiplex on", volume.Name))
+    commands = append(commands, fmt.Sprintf("gluster --mode=script volume %v set transport.listen-backlog 100", volume.Name))
+
 	commands = append(commands, fmt.Sprintf("gluster --mode=script volume start %v", volume.Name))
 
 	_, err := s.RemoteExecutor.RemoteCommandExecute(host, commands, 10)


### PR DESCRIPTION
Add fix for offline bricks in case of Many Bricks per Node.

Add additional volume parameters for every created volume:
cluster.brick-multiplex on
transport.listen-backlog <HEKETI_TRANSPORT_LISTEN_BACKLOG_OPTION>/100